### PR TITLE
fix:mention list can be null.

### DIFF
--- a/LeanCloud.Realtime/Internal/Command/MessageCommand.cs
+++ b/LeanCloud.Realtime/Internal/Command/MessageCommand.cs
@@ -66,8 +66,15 @@ namespace LeanCloud.Realtime.Internal
 
         public MessageCommand Mention(IEnumerable<string> clientIds)
         {
-            var mentionedMembers = clientIds.ToList();
-            return new MessageCommand(this.Argument("mentionPids", mentionedMembers));
+            if (clientIds == null)
+            {
+                return this;
+            }
+            else
+            {
+                var mentionedMembers = clientIds.ToList();
+                return new MessageCommand(this.Argument("mentionPids", mentionedMembers));
+            }
         }
 
         public MessageCommand MentionAll(bool mentionAll)


### PR DESCRIPTION
比如私聊时就会出错。Unity的错误信息真是完全没用。
这个修改解决了我的问题，但不太确定是不是可以/应该这样改。