### PR TITLE
fix: 修复在「手动标记已读」的状态下，收到消息并手动标记后，但 unread 消息数量不对的 bug

### DIFF
--- a/LeanCloud.Realtime/Public/AVIMConversation.cs
+++ b/LeanCloud.Realtime/Public/AVIMConversation.cs
@@ -776,6 +776,7 @@ namespace LeanCloud.Realtime
             }
             return this.CurrentClient.ReadAsync(this, message, readAt).OnSuccess(t =>
             {
+                Received = null;
                 _lastUnreadWhenOpenSession = null;
                 Read = new ReadState()
                 {


### PR DESCRIPTION
#134 
心动的香肠派对遇到了这个问题，现已修复。
中间状态太多，修复依据是尽量减少增删的代码，后面再做重构。